### PR TITLE
feat(entrypoint): Handle user operations atomically

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: test deploy
+test:
+	npx hardhat test test/entrypoint.atomic.test.ts
+
+deploy:
+	npx hardhat deploy --network dev
+
+

--- a/contracts/core/EntryPoint.sol
+++ b/contracts/core/EntryPoint.sol
@@ -184,10 +184,10 @@ contract EntryPoint is IEntryPoint, StakeManager, NonceManager, ReentrancyGuard,
             }
             if (methodSig == IAccountExecute.executeUserOp.selector) {
                 bytes memory executeUserOp = abi.encodeCall(IAccountExecute.executeUserOp, (userOp, opInfo.userOpHash));
-                innerCall = abi.encodeCall(this.innerHandleOp, (executeUserOp, opInfo, context));
+                innerCall = abi.encodeCall(this.innerHandleOpAtomic, (executeUserOp, opInfo, context));
             } else
             {
-                innerCall = abi.encodeCall(this.innerHandleOp, (callData, opInfo, context));
+                innerCall = abi.encodeCall(this.innerHandleOpAtomic, (callData, opInfo, context));
             }
             assembly ("memory-safe") {
                 success := call(gas(), address(), 0, add(innerCall, 0x20), mload(innerCall), 0, 32)
@@ -195,6 +195,7 @@ contract EntryPoint is IEntryPoint, StakeManager, NonceManager, ReentrancyGuard,
                 mstore(0x40, saveFreePtr)
             }
         }
+
         if (!success) {
             bytes32 innerRevertCode;
             assembly ("memory-safe") {
@@ -457,6 +458,46 @@ contract EntryPoint is IEntryPoint, StakeManager, NonceManager, ReentrancyGuard,
                     );
                 }
                 mode = IPaymaster.PostOpMode.opReverted;
+            }
+        }
+
+        unchecked {
+            uint256 actualGas = preGas - gasleft() + opInfo.preOpGas;
+            return _postExecution(mode, opInfo, context, actualGas);
+        }
+    }
+
+
+    function innerHandleOpAtomic(
+        bytes memory callData,
+        UserOpInfo memory opInfo,
+        bytes calldata context
+    ) external returns (uint256 actualGasCost) {
+        uint256 preGas = gasleft();
+        require(msg.sender == address(this), "AA92 internal call only");
+        MemoryUserOp memory mUserOp = opInfo.mUserOp;
+
+        uint256 callGasLimit = mUserOp.callGasLimit;
+        unchecked {
+            // handleOps was called with gas limit too low. abort entire bundle.
+            if (
+                gasleft() * 63 / 64 <
+                callGasLimit +
+                mUserOp.paymasterPostOpGasLimit +
+                INNER_GAS_OVERHEAD
+            ) {
+                assembly ("memory-safe") {
+                    mstore(0, INNER_OUT_OF_GAS)
+                    revert(0, 32)
+                }
+            }
+        }
+
+        IPaymaster.PostOpMode mode = IPaymaster.PostOpMode.opSucceeded;
+        if (callData.length > 0) {
+            bool success = Exec.call(mUserOp.sender, 0, callData, callGasLimit);
+            if (!success) {
+                revert FailedOp(0, "Atomic Operation failed");
             }
         }
 

--- a/contracts/core/EntryPoint.sol
+++ b/contracts/core/EntryPoint.sol
@@ -149,6 +149,79 @@ contract EntryPoint is IEntryPoint, StakeManager, NonceManager, ReentrancyGuard,
             }
         }
     }
+    
+    /**
+     * Execute a user operation.
+     * @param opIndex    - Index into the opInfo array.
+     * @param userOp     - The userOp to execute.
+     * @param opInfo     - The opInfo filled by validatePrepayment for this userOp.
+     * @return collected - The total amount this userOp paid.
+     */
+    function _executeUserOpAtomic(
+        uint256 opIndex,
+        PackedUserOperation calldata userOp,
+        UserOpInfo memory opInfo
+    )
+    internal
+    returns
+    (uint256 collected) {
+        uint256 preGas = gasleft();
+        bytes memory context = getMemoryBytesFromOffset(opInfo.contextOffset);
+        bool success;
+        {
+            uint256 saveFreePtr;
+            assembly ("memory-safe") {
+                saveFreePtr := mload(0x40)
+            }
+            bytes calldata callData = userOp.callData;
+            bytes memory innerCall;
+            bytes4 methodSig;
+            assembly {
+                let len := callData.length
+                if gt(len, 3) {
+                    methodSig := calldataload(callData.offset)
+                }
+            }
+            if (methodSig == IAccountExecute.executeUserOp.selector) {
+                bytes memory executeUserOp = abi.encodeCall(IAccountExecute.executeUserOp, (userOp, opInfo.userOpHash));
+                innerCall = abi.encodeCall(this.innerHandleOp, (executeUserOp, opInfo, context));
+            } else
+            {
+                innerCall = abi.encodeCall(this.innerHandleOp, (callData, opInfo, context));
+            }
+            assembly ("memory-safe") {
+                success := call(gas(), address(), 0, add(innerCall, 0x20), mload(innerCall), 0, 32)
+                collected := mload(0)
+                mstore(0x40, saveFreePtr)
+            }
+        }
+        if (!success) {
+            bytes32 innerRevertCode;
+            assembly ("memory-safe") {
+                let len := returndatasize()
+                if eq(32,len) {
+                    returndatacopy(0, 0, 32)
+                    innerRevertCode := mload(0)
+                }
+            }
+            if (innerRevertCode == INNER_OUT_OF_GAS) {
+                // handleOps was called with gas limit too low. abort entire bundle.
+                //can only be caused by bundler (leaving not enough gas for inner call)
+                revert FailedOp(opIndex, "AA95 out of gas");
+            } else if (innerRevertCode == INNER_REVERT_LOW_PREFUND) {
+                // innerCall reverted on prefund too low. treat entire prefund as "gas cost"
+                uint256 actualGas = preGas - gasleft() + opInfo.preOpGas;
+                uint256 actualGasCost = opInfo.prefund;
+                emitPrefundTooLow(opInfo);
+                emitUserOperationEvent(opInfo, false, actualGasCost, actualGas);
+                collected = actualGasCost;
+            } else {
+                revert FailedOp(opIndex, "Operation failed");
+            }
+        }
+    }
+
+
 
     function emitUserOperationEvent(UserOpInfo memory opInfo, bool success, uint256 actualGasCost, uint256 actualGas) internal virtual {
         emit UserOperationEvent(
@@ -198,6 +271,40 @@ contract EntryPoint is IEntryPoint, StakeManager, NonceManager, ReentrancyGuard,
 
             for (uint256 i = 0; i < opslen; i++) {
                 collected += _executeUserOp(i, ops[i], opInfos[i]);
+            }
+
+            _compensate(beneficiary, collected);
+        }
+    }
+
+
+    function handleAtomicOps(
+        PackedUserOperation[] calldata ops,
+        address payable beneficiary
+    ) public nonReentrant {
+        uint256 opslen = ops.length;
+        UserOpInfo[] memory opInfos = new UserOpInfo[](opslen);
+
+        unchecked {
+            for (uint256 i = 0; i < opslen; i++) {
+                UserOpInfo memory opInfo = opInfos[i];
+                (
+                    uint256 validationData,
+                    uint256 pmValidationData
+                ) = _validatePrepayment(i, ops[i], opInfo);
+                _validateAccountAndPaymasterValidationData(
+                    i,
+                    validationData,
+                    pmValidationData,
+                    address(0)
+                );
+            }
+
+            uint256 collected = 0;
+            emit BeforeExecution();
+
+            for (uint256 i = 0; i < opslen; i++) {
+                collected += _executeUserOpAtomic(i, ops[i], opInfos[i]);
             }
 
             _compensate(beneficiary, collected);

--- a/test/entrypoint.atomic.test.ts
+++ b/test/entrypoint.atomic.test.ts
@@ -92,60 +92,95 @@ describe('EntryPoint', function () {
     expect(getUserOpHash(sampleOp, entryPoint.address, chainId)).to.eql(await entryPoint.getUserOpHash(packedOp))
   })
 
+  describe('with paymaster (account with no eth)', () => {
+    let paymaster: TestPaymasterAcceptAll
+    let counter: TestCounter
+    let accountExecFromEntryPoint: PopulatedTransaction
+    const account2Owner = createAccountOwner()
 
+    before(async () => {
+      paymaster = await new TestPaymasterAcceptAll__factory(ethersSigner).deploy(entryPoint.address)
+      await paymaster.addStake(globalUnstakeDelaySec, { value: paymasterStake })
+      counter = await new TestCounter__factory(ethersSigner).deploy()
+      const count = await counter.populateTransaction.count()
+      accountExecFromEntryPoint = await account.populateTransaction.execute(counter.address, 0, count.data!)
+    })
 
-    describe('with paymaster (account with no eth)', () => {
-      let paymaster: TestPaymasterAcceptAll
-      let counter: TestCounter
-      let accountExecFromEntryPoint: PopulatedTransaction
+  
+
+    it('should execute two transfers atomically in one tx', async function () {
+      await paymaster.deposit({ value: ONE_ETH })
+
+      // Create two account owners
+      const account1Owner = createAccountOwner()
       const account2Owner = createAccountOwner()
 
-      before(async () => {
-        paymaster = await new TestPaymasterAcceptAll__factory(ethersSigner).deploy(entryPoint.address)
-        await paymaster.addStake(globalUnstakeDelaySec, { value: paymasterStake })
-        counter = await new TestCounter__factory(ethersSigner).deploy()
-        const count = await counter.populateTransaction.count()
-        accountExecFromEntryPoint = await account.populateTransaction.execute(counter.address, 0, count.data!)
+      // Create two accounts
+      const account1 = await createAccount(ethersSigner, await account1Owner.getAddress(), entryPoint.address)
+      const account2 = await createAccount(ethersSigner, await account2Owner.getAddress(), entryPoint.address)
+
+      // Fund account1 for testing
+      await ethersSigner.sendTransaction({
+        to: account1.proxy.address,
+        value: parseEther('2')
       })
 
+      // GErt account 1 and account 2 balance 
+      const account1Balance = await getBalance(account1.proxy.address)
+      const account2Balance = await getBalance(account2.proxy.address)
+      console.log('account1Balance', account1Balance)
+      console.log('account2Balance', account2Balance)
 
-      it('paymaster should pay for tx', async function () {
-        await paymaster.deposit({ value: ONE_ETH })
-        const op = await fillSignAndPack({
-          paymaster: paymaster.address,
-          paymasterVerificationGasLimit: 1e6,
-          callData: accountExecFromEntryPoint.data,
-          initCode: getAccountInitCode(account2Owner.address, simpleAccountFactory)
-        }, account2Owner, entryPoint)
-        const beneficiaryAddress = createAddress()
+      // Create two destinations for transfers
+      const destination = createAddress()
+      
+      // Create transfer operations
+      const transferOp1 = await fillSignAndPack({
+        sender: account1.proxy.address,
+        callData: account1.proxy.interface.encodeFunctionData('execute', [
+          account2.proxy.address,
+          parseEther('1'),
+          '0x'
+        ]),
+        paymaster: paymaster.address,
+        paymasterVerificationGasLimit: 1e6,
+        callGasLimit: 2e6,
+        verificationGasLimit: 2e6
+      }, account1Owner, entryPoint)
 
-        const rcpt = await entryPoint.handleAtomicOps([op], beneficiaryAddress).then(async t => t.wait())
+      const transferOp2 = await fillSignAndPack({
+        sender: account2.proxy.address,
+        callData: account2.proxy.interface.encodeFunctionData('execute', [
+          destination,
+          parseEther('1.5'),
+          '0x'
+        ]),
+        paymaster: paymaster.address,
+        paymasterVerificationGasLimit: 1e6,
+        callGasLimit: 2e6,
+        verificationGasLimit: 2e6
+      }, account2Owner, entryPoint)
 
-        const { actualGasCost } = await calcGasUsage(rcpt, entryPoint, beneficiaryAddress)
-        const paymasterPaid = ONE_ETH.sub(await entryPoint.balanceOf(paymaster.address))
-        expect(paymasterPaid).to.eql(actualGasCost)
-      })
-      it('simulateValidation should return paymaster stake and delay', async () => {
-        await paymaster.deposit({ value: ONE_ETH })
-        const anOwner = createAccountOwner()
+      const beneficiaryAddress = createAddress()
 
-        const op = await fillSignAndPack({
-          paymaster: paymaster.address,
-          paymasterVerificationGasLimit: 1e6,
-          callData: accountExecFromEntryPoint.data,
-          initCode: getAccountInitCode(anOwner.address, simpleAccountFactory)
-        }, anOwner, entryPoint)
+      // Execute both transfers atomically
+      const rcpt = await entryPoint.handleAtomicOps(
+        [transferOp1, transferOp2],
+        beneficiaryAddress
+      ).then(async t => t.wait())
 
-        const { paymasterInfo } = await simulateValidation(op, entryPoint.address)
-        const {
-          stake: simRetStake,
-          unstakeDelaySec: simRetDelay
-        } = paymasterInfo
 
-        expect(simRetStake).to.eql(paymasterStake)
-        expect(simRetDelay).to.eql(globalUnstakeDelaySec)
-      })
-    })
+      // Verify both transfers succeeded
+      const balance = await getBalance(destination)
+      console.log('balance', balance)
+    
+      // get account 1 and account 2 balance
+      const account1BalanceAfter = await getBalance(account1.proxy.address)
+      const account2BalanceAfter = await getBalance(account2.proxy.address)
+      console.log('account1BalanceAfter', account1BalanceAfter)
+      console.log('account2BalanceAfter', account2BalanceAfter)
      
+    })
+  })
 })
  

--- a/test/entrypoint.atomic.test.ts
+++ b/test/entrypoint.atomic.test.ts
@@ -1,0 +1,151 @@
+import './aa.init'
+import { BigNumber, Event, Wallet } from 'ethers'
+import { expect } from 'chai'
+import {
+  SimpleAccount,
+  SimpleAccountFactory,
+  TestAggregatedAccount__factory,
+  TestAggregatedAccountFactory__factory,
+  TestCounter,
+  TestCounter__factory,
+  TestExpirePaymaster,
+  TestExpirePaymaster__factory,
+  TestExpiryAccount,
+  TestExpiryAccount__factory,
+  TestPaymasterAcceptAll,
+  TestPaymasterAcceptAll__factory,
+  TestRevertAccount__factory,
+  TestAggregatedAccount,
+  TestSignatureAggregator,
+  TestSignatureAggregator__factory,
+  MaliciousAccount__factory,
+  TestWarmColdAccount__factory,
+  TestPaymasterRevertCustomError__factory,
+  IEntryPoint__factory,
+  SimpleAccountFactory__factory,
+  IStakeManager__factory,
+  INonceManager__factory,
+  EntryPoint,
+  TestPaymasterWithPostOp__factory,
+  TestPaymasterWithPostOp
+} from '../typechain'
+import {
+  AddressZero,
+  createAccountOwner,
+  fund,
+  checkForGeth,
+  rethrow,
+  tostr,
+  getAccountInitCode,
+  calcGasUsage,
+  ONE_ETH,
+  TWO_ETH,
+  deployEntryPoint,
+  getBalance,
+  createAddress,
+  getAccountAddress,
+  HashZero,
+  createAccount,
+  getAggregatedAccountInitCode,
+  decodeRevertReason, parseValidationData, findUserOpWithMin
+} from './testutils'
+import { DefaultsForUserOp, fillAndSign, fillSignAndPack, getUserOpHash, packUserOp, simulateValidation } from './UserOp'
+import { PackedUserOperation, UserOperation } from './UserOperation'
+import { PopulatedTransaction } from 'ethers/lib/ethers'
+import { ethers } from 'hardhat'
+import { arrayify, defaultAbiCoder, hexZeroPad, parseEther } from 'ethers/lib/utils'
+import { debugTransaction } from './debugTx'
+import { BytesLike } from '@ethersproject/bytes'
+import { toChecksumAddress } from 'ethereumjs-util'
+import { getERC165InterfaceID } from '../src/Utils'
+import { UserOperationEventEvent } from '../typechain/contracts/interfaces/IEntryPoint'
+
+describe('EntryPoint', function () {
+  let entryPoint: EntryPoint
+  let simpleAccountFactory: SimpleAccountFactory
+
+  let accountOwner: Wallet
+  const ethersSigner = ethers.provider.getSigner()
+  let account: SimpleAccount
+
+  const globalUnstakeDelaySec = 2
+  const paymasterStake = ethers.utils.parseEther('2')
+
+  before(async function () {
+    this.timeout(20000)
+    await checkForGeth()
+
+    const chainId = await ethers.provider.getNetwork().then(net => net.chainId)
+
+    entryPoint = await deployEntryPoint()
+
+    accountOwner = createAccountOwner();
+    ({
+      proxy: account,
+      accountFactory: simpleAccountFactory
+    } = await createAccount(ethersSigner, await accountOwner.getAddress(), entryPoint.address))
+    await fund(account)
+
+    // sanity: validate helper functions
+    const sampleOp = await fillAndSign({ sender: account.address }, accountOwner, entryPoint)
+    const packedOp = packUserOp(sampleOp)
+    expect(getUserOpHash(sampleOp, entryPoint.address, chainId)).to.eql(await entryPoint.getUserOpHash(packedOp))
+  })
+
+
+
+    describe('with paymaster (account with no eth)', () => {
+      let paymaster: TestPaymasterAcceptAll
+      let counter: TestCounter
+      let accountExecFromEntryPoint: PopulatedTransaction
+      const account2Owner = createAccountOwner()
+
+      before(async () => {
+        paymaster = await new TestPaymasterAcceptAll__factory(ethersSigner).deploy(entryPoint.address)
+        await paymaster.addStake(globalUnstakeDelaySec, { value: paymasterStake })
+        counter = await new TestCounter__factory(ethersSigner).deploy()
+        const count = await counter.populateTransaction.count()
+        accountExecFromEntryPoint = await account.populateTransaction.execute(counter.address, 0, count.data!)
+      })
+
+
+      it('paymaster should pay for tx', async function () {
+        await paymaster.deposit({ value: ONE_ETH })
+        const op = await fillSignAndPack({
+          paymaster: paymaster.address,
+          paymasterVerificationGasLimit: 1e6,
+          callData: accountExecFromEntryPoint.data,
+          initCode: getAccountInitCode(account2Owner.address, simpleAccountFactory)
+        }, account2Owner, entryPoint)
+        const beneficiaryAddress = createAddress()
+
+        const rcpt = await entryPoint.handleAtomicOps([op], beneficiaryAddress).then(async t => t.wait())
+
+        const { actualGasCost } = await calcGasUsage(rcpt, entryPoint, beneficiaryAddress)
+        const paymasterPaid = ONE_ETH.sub(await entryPoint.balanceOf(paymaster.address))
+        expect(paymasterPaid).to.eql(actualGasCost)
+      })
+      it('simulateValidation should return paymaster stake and delay', async () => {
+        await paymaster.deposit({ value: ONE_ETH })
+        const anOwner = createAccountOwner()
+
+        const op = await fillSignAndPack({
+          paymaster: paymaster.address,
+          paymasterVerificationGasLimit: 1e6,
+          callData: accountExecFromEntryPoint.data,
+          initCode: getAccountInitCode(anOwner.address, simpleAccountFactory)
+        }, anOwner, entryPoint)
+
+        const { paymasterInfo } = await simulateValidation(op, entryPoint.address)
+        const {
+          stake: simRetStake,
+          unstakeDelaySec: simRetDelay
+        } = paymasterInfo
+
+        expect(simRetStake).to.eql(paymasterStake)
+        expect(simRetDelay).to.eql(globalUnstakeDelaySec)
+      })
+    })
+     
+})
+ 


### PR DESCRIPTION
allow handle atomic user operations 

- Add new handleOpsAtomic(useroperations[]) on the EntryPoint contract

## users now can

1. Collaborate and send any two arbitrary user operations. For example, user A send fund to B, then B send fund to C (or call contract C), as long as both sign the user operation